### PR TITLE
FIX:CrewQueryRepository 활동 없는 crew도 조회되도록 수정

### DIFF
--- a/src/main/java/com/runmate/repository/crew/CrewQueryRepository.java
+++ b/src/main/java/com/runmate/repository/crew/CrewQueryRepository.java
@@ -30,7 +30,7 @@ public class CrewQueryRepository {
     public List<CrewGetDto> findByLocationWithSorted(Region region, Pageable pageable, CrewOrderSpec orderSpec) {
         return queryFactory.select(getCrewGetDtoConstructor())
                 .from(activity)
-                .innerJoin(activity.user, user)
+                .rightJoin(activity.user, user)
                 .innerJoin(user.crewUser, crewUser)
                 .innerJoin(crewUser.crew, crew)
                 .where(eqSi(region.getSi()), eqGu(region.getGu()), eqGun(region.getGun()))


### PR DESCRIPTION
CrewUser없는 Crew는 로직상 존재할 수 없기 때문에(admin)
CrewUser없는 Crew가 조회가 안되는 버그는 있을 수 없으므로 이는 그대로 유지.