### PR TITLE
Features/#65

### DIFF
--- a/runmate-domain/src/main/java/com/runmate/domain/redis/TeamInfo.java
+++ b/runmate-domain/src/main/java/com/runmate/domain/redis/TeamInfo.java
@@ -89,7 +89,7 @@ public class TeamInfo {
     @JsonIgnore
     public boolean isCurrentTimeBeforeStartedAt() {
         LocalDateTime currentTime = now();
-        return currentTime.isBefore(getEndTime());
+        return currentTime.isBefore(this.getGoal().getStartedAt());
     }
 
     public void participateRunning(Long memberId) {

--- a/runmate-domain/src/main/java/com/runmate/domain/redis/TeamInfo.java
+++ b/runmate-domain/src/main/java/com/runmate/domain/redis/TeamInfo.java
@@ -87,9 +87,9 @@ public class TeamInfo {
     }
 
     @JsonIgnore
-    public boolean isCurrentTimeLargerThanStartedAt() {
+    public boolean isCurrentTimeBeforeStartedAt() {
         LocalDateTime currentTime = now();
-        return currentTime.isAfter(getEndTime()) || currentTime.isEqual(getEndTime());
+        return currentTime.isBefore(getEndTime());
     }
 
     public void participateRunning(Long memberId) {
@@ -114,7 +114,7 @@ public class TeamInfo {
     }
 
     private void checkNowIsBetweenStartedAndRunningSeconds() {
-        if (isTimeOver() || isCurrentTimeLargerThanStartedAt())
+        if (isTimeOver() || isCurrentTimeBeforeStartedAt())
             throw new CurrentIsNotRunningTimeException();
     }
 }

--- a/runmate-domain/src/main/java/com/runmate/domain/redis/TeamInfo.java
+++ b/runmate-domain/src/main/java/com/runmate/domain/redis/TeamInfo.java
@@ -1,6 +1,7 @@
 package com.runmate.domain.redis;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.runmate.domain.running.Goal;
 import com.runmate.exception.AdminNotIncludedException;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -25,7 +26,7 @@ public class TeamInfo {
     private GoalForTempStore goal;
     private long runningSeconds;
 
-    @Builder
+    @Builder(builderMethodName = "builder")
     public TeamInfo(long teamId, long adminId, GoalForTempStore goal) {
         this.teamId = teamId;
         this.goal = goal;
@@ -34,6 +35,20 @@ public class TeamInfo {
 
         this.totalDistance = 0;
         this.runningSeconds = 0;
+    }
+
+    @Builder(builderMethodName = "fromGoal", builderClassName = "forMove")
+    public TeamInfo(long teamId, long adminId, Goal goal) {
+        this.teamId = teamId;
+        this.adminId = adminId;
+        this.totalDistance = 0;
+        this.runningSeconds = 0;
+
+        this.goal = GoalForTempStore.builder()
+                .startedAt(goal.getStartedAt())
+                .distance(goal.getTotalDistance())
+                .runningSeconds(goal.getTotalRunningSeconds())
+                .build();
     }
 
     public float increaseTotalDistance(float distance) {

--- a/runmate-domain/src/main/java/com/runmate/domain/redis/TeamInfo.java
+++ b/runmate-domain/src/main/java/com/runmate/domain/redis/TeamInfo.java
@@ -43,11 +43,12 @@ public class TeamInfo {
     }
 
     @Builder(builderMethodName = "fromGoal", builderClassName = "forMove")
-    public TeamInfo(long teamId, long adminId, Goal goal) {
+    public TeamInfo(long teamId, long adminId, Goal goal, List<Long> totalMembers) {
         this.teamId = teamId;
         this.adminId = adminId;
         this.totalDistance = 0;
         this.runningSeconds = 0;
+        this.totalMembers = totalMembers;
 
         this.goal = GoalForTempStore.builder()
                 .startedAt(goal.getStartedAt())

--- a/runmate-domain/src/main/java/com/runmate/domain/running/Team.java
+++ b/runmate-domain/src/main/java/com/runmate/domain/running/Team.java
@@ -6,6 +6,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -25,6 +27,9 @@ public class Team {
 
     @Embedded
     private Result result;
+
+    @OneToMany(mappedBy = "team", fetch = FetchType.LAZY)
+    private List<TeamMember> teamMembers = new ArrayList<>();
 
     @Builder
     public Team(String title, Goal goal) {

--- a/runmate-domain/src/main/java/com/runmate/domain/running/TeamMember.java
+++ b/runmate-domain/src/main/java/com/runmate/domain/running/TeamMember.java
@@ -19,7 +19,7 @@ public class TeamMember {
     private Long id;
 
     @JoinColumn(name = "crew_user_id")
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     private CrewUser crewUser;
 
     @JoinColumn(name = "team_id")

--- a/runmate-domain/src/main/java/com/runmate/exception/CurrentIsNotRunningTimeException.java
+++ b/runmate-domain/src/main/java/com/runmate/exception/CurrentIsNotRunningTimeException.java
@@ -1,0 +1,10 @@
+package com.runmate.exception;
+
+public class CurrentIsNotRunningTimeException extends RuntimeException {
+    public CurrentIsNotRunningTimeException() {
+    }
+
+    public CurrentIsNotRunningTimeException(String message) {
+        super(message);
+    }
+}

--- a/runmate-domain/src/main/java/com/runmate/exception/MemberNotIncludedTeamException.java
+++ b/runmate-domain/src/main/java/com/runmate/exception/MemberNotIncludedTeamException.java
@@ -1,0 +1,10 @@
+package com.runmate.exception;
+
+public class MemberNotIncludedTeamException extends RuntimeException {
+    public MemberNotIncludedTeamException() {
+    }
+
+    public MemberNotIncludedTeamException(String message) {
+        super(message);
+    }
+}

--- a/runmate-domain/src/main/java/com/runmate/repository/running/TeamMemberRepository.java
+++ b/runmate-domain/src/main/java/com/runmate/repository/running/TeamMemberRepository.java
@@ -1,7 +1,11 @@
 package com.runmate.repository.running;
 
+import com.runmate.domain.running.Team;
 import com.runmate.domain.running.TeamMember;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface TeamMemberRepository extends JpaRepository<TeamMember, Long> {
+    Optional<TeamMember> findByIdAndTeam(Long id, Team team);
 }

--- a/runmate-domain/src/main/java/com/runmate/repository/running/TeamRepository.java
+++ b/runmate-domain/src/main/java/com/runmate/repository/running/TeamRepository.java
@@ -2,6 +2,12 @@ package com.runmate.repository.running;
 
 import com.runmate.domain.running.Team;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface TeamRepository extends JpaRepository<Team, Long> {
+    @Query("SELECT T FROM Team T join fetch T.teamMembers where T.id =:teamId")
+    Optional<Team> findByIdHaveTeamMembers(@Param("teamId") Long teamId);
 }

--- a/runmate-domain/src/main/resources/db/migration/V2.2__TeamRunning_DummyData.sql
+++ b/runmate-domain/src/main/resources/db/migration/V2.2__TeamRunning_DummyData.sql
@@ -1,0 +1,18 @@
+insert into team(id, title, goal_total_distance, goal_running_seconds, result_total_distance,
+                 result_total_running_seconds)
+values (1, "let's run1", 10, 3600, 0, 0);
+
+insert into team_member(crew_user_id, team_id, individual_distance, individual_running_seconds)
+values (1, 1, 0, 0);
+
+insert into team_member(crew_user_id, team_id, individual_distance, individual_running_seconds)
+values (2, 1, 0, 0);
+
+insert into team_member(crew_user_id, team_id, individual_distance, individual_running_seconds)
+values (3, 1, 0, 0);
+
+insert into team_member(crew_user_id, team_id, individual_distance, individual_running_seconds)
+values (4, 1, 0, 0);
+
+insert into team_member(crew_user_id, team_id, individual_distance, individual_running_seconds)
+values (5, 1, 0, 0);

--- a/runmate-domain/src/test/java/com/runmate/repository/TeamMemberRepositoryTest.java
+++ b/runmate-domain/src/test/java/com/runmate/repository/TeamMemberRepositoryTest.java
@@ -14,6 +14,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @SpringBootTest
 @Transactional
@@ -63,6 +64,21 @@ public class TeamMemberRepositoryTest {
 
         TeamMember result = teamMemberRepository.findById(teamMember.getId()).get();
         checkSameTeamMember(teamMember, result);
+    }
+
+    @Test
+    public void When_findByIdAndTeam() {
+        TeamMember teamMember = TeamMember.builder()
+                .team(team)
+                .crewUser(crewUser)
+                .build();
+        teamMemberRepository.save(teamMember);
+
+        //when
+        TeamMember result = teamMemberRepository.findByIdAndTeam(teamMember.getId(), team).orElse(null);
+        //then
+        assertNotNull(result);
+        assertEquals(result.getTeam().getId(), team.getId());
     }
 
     void checkSameTeamMember(TeamMember one, TeamMember another) {

--- a/runmate-domain/src/test/java/com/runmate/repository/TeamRepositoryTest.java
+++ b/runmate-domain/src/test/java/com/runmate/repository/TeamRepositoryTest.java
@@ -11,6 +11,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @SpringBootTest
 @Transactional
@@ -45,6 +46,16 @@ public class TeamRepositoryTest {
 
         Team result = teamRepository.findById(team.getId()).get();
         checkSameTeam(team, result);
+    }
+
+    @Test
+    void When_findByIdHaveTeamMembers() {
+        final Long teamId = 1L;
+        final int numOfTeamMember = 5;
+        Team team = teamRepository.findByIdHaveTeamMembers(teamId).orElse(null);
+
+        assertNotNull(team);
+        assertEquals(numOfTeamMember, team.getTeamMembers().size());
     }
 
     void checkSameTeam(Team one, Team another) {

--- a/runmate-websocket/src/main/java/com/runmate/service/RunningDataMoveService.java
+++ b/runmate-websocket/src/main/java/com/runmate/service/RunningDataMoveService.java
@@ -17,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static com.runmate.repository.redis.MemberInfoRepository.memberKey;
 import static com.runmate.repository.redis.TeamInfoRepository.teamKey;
@@ -53,10 +54,16 @@ public class RunningDataMoveService {
     public void persistRunningDataToMem(Long teamId, Long memberId) {
         TeamInfo teamInfo = teamInfoRepository.findById(teamId).orElse(null);
         if (teamInfo == null) {
-            Team team = teamRepository.findById(teamId).orElseThrow(NotFoundTeamException::new);
+            Team team = teamRepository.findByIdHaveTeamMembers(teamId).orElseThrow(NotFoundTeamException::new);
+            List<Long> totalMembers = team.getTeamMembers()
+                    .stream()
+                    .map(teamMember -> teamMember.getId())
+                    .collect(Collectors.toList());
+
             teamInfo = TeamInfo.fromGoal()
                     .teamId(teamId)
                     .goal(team.getGoal())
+                    .totalMembers(totalMembers)
                     .build();
         }
 

--- a/runmate-websocket/src/main/java/com/runmate/service/RunningDataMoveService.java
+++ b/runmate-websocket/src/main/java/com/runmate/service/RunningDataMoveService.java
@@ -40,7 +40,7 @@ public class RunningDataMoveService {
         Team team = teamRepository.findById(teamId).orElseThrow(NotFoundTeamException::new);
         team.decideResult(teamInfo.getTotalDistance(), teamInfo.getRunningSeconds(), teamInfo.isSuccessOnRunning());
 
-        teamInfo.getMembers().forEach(memberId -> {
+        teamInfo.getTotalMembers().forEach(memberId -> {
             MemberInfo memberInfo = memberInfoRepository.findById(memberId).orElseThrow(NotFoundMemberInfoException::new);
             TeamMember teamMember = teamMemberRepository.findById(memberId).orElseThrow(NotFoundTeamMemberException::new);
             teamMember.decideResult(teamInfo.getRunningSeconds(), memberInfo.getTotalDistance());
@@ -60,7 +60,7 @@ public class RunningDataMoveService {
                     .build();
         }
 
-        teamInfo.getMembers().add(memberId);
+        teamInfo.participateRunning(memberId);
         teamInfoRepository.save(teamInfo);
 
         if (memberInfoRepository.findById(memberId).equals(Optional.empty())) {

--- a/runmate-websocket/src/test/java/com/runmate/TestActiveProfilesResolver.java
+++ b/runmate-websocket/src/test/java/com/runmate/TestActiveProfilesResolver.java
@@ -1,0 +1,16 @@
+package com.runmate;
+
+import org.springframework.test.context.ActiveProfilesResolver;
+
+public class TestActiveProfilesResolver implements ActiveProfilesResolver {
+
+    @Override
+    public String[] resolve(Class<?> testClass) {
+        String profile = System.getProperty("profile");
+
+        if (profile == null) {
+            profile = "local";
+        }
+        return new String[]{profile};
+    }
+}

--- a/runmate-websocket/src/test/java/com/runmate/service/JudgeRunningDataServiceTest.java
+++ b/runmate-websocket/src/test/java/com/runmate/service/JudgeRunningDataServiceTest.java
@@ -1,5 +1,6 @@
 package com.runmate.service;
 
+import com.runmate.TestActiveProfilesResolver;
 import com.runmate.domain.redis.GoalForTempStore;
 import com.runmate.domain.redis.TeamInfo;
 import com.runmate.repository.redis.MemberInfoRepository;
@@ -9,17 +10,18 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.Iterator;
-import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @SpringBootTest
 @Transactional
+@ActiveProfiles(inheritProfiles = false, resolver = TestActiveProfilesResolver.class)
 public class JudgeRunningDataServiceTest {
     @Autowired
     JudgeRunningDataService judgeRunningDataService;

--- a/runmate-websocket/src/test/java/com/runmate/service/RunningDataManageServiceTest.java
+++ b/runmate-websocket/src/test/java/com/runmate/service/RunningDataManageServiceTest.java
@@ -1,5 +1,6 @@
 package com.runmate.service;
 
+import com.runmate.TestActiveProfilesResolver;
 import com.runmate.domain.redis.GoalForTempStore;
 import com.runmate.domain.redis.MemberInfo;
 import com.runmate.domain.redis.TeamInfo;
@@ -12,6 +13,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
@@ -24,6 +26,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
 @Transactional
+@ActiveProfiles(inheritProfiles = false, resolver = TestActiveProfilesResolver.class)
 public class RunningDataManageServiceTest {
     @Autowired
     RunningDataManageService runningDataManageService;

--- a/runmate-websocket/src/test/java/com/runmate/service/RunningDataMoveToDiskTest.java
+++ b/runmate-websocket/src/test/java/com/runmate/service/RunningDataMoveToDiskTest.java
@@ -25,10 +25,12 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
+import static java.time.LocalDateTime.now;
 import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
@@ -58,9 +60,9 @@ public class RunningDataMoveToDiskTest {
     void loadData() {
         //init rdbms
         final int numOfMember = 5;
-        final long goalSeconds = 3600L;
+        final long goalSeconds = 3800L;
         final float goalDistance = 10F;
-        final LocalDateTime startedAt = LocalDateTime.now();
+        final LocalDateTime startedAt = now().minus(1, ChronoUnit.HOURS);
         final int adminIndex = 0;
         memberIds = new ArrayList<>();
         memberInfos = new ArrayList<>();
@@ -101,6 +103,7 @@ public class RunningDataMoveToDiskTest {
                 .teamId(team.getId())
                 .adminId(memberIds.get(adminIndex))
                 .goal(goalForTempStore)
+                .totalMembers(memberIds)
                 .build();
         teamInfo.increaseTotalDistance(0.5F);
 

--- a/runmate-websocket/src/test/java/com/runmate/service/RunningDataMoveToDiskTest.java
+++ b/runmate-websocket/src/test/java/com/runmate/service/RunningDataMoveToDiskTest.java
@@ -111,7 +111,7 @@ public class RunningDataMoveToDiskTest {
                     .build();
             memberInfo.increaseTotalDistance(0.1F);
 
-            teamInfo.getMembers().add(memberId);
+            teamInfo.getOnlineMembers().add(memberId);
             memberInfoRepository.save(memberInfo);
         });
         teamInfoRepository.save(teamInfo);

--- a/runmate-websocket/src/test/java/com/runmate/service/RunningDataMoveToDiskTest.java
+++ b/runmate-websocket/src/test/java/com/runmate/service/RunningDataMoveToDiskTest.java
@@ -1,5 +1,6 @@
 package com.runmate.service;
 
+import com.runmate.TestActiveProfilesResolver;
 import com.runmate.domain.crew.Crew;
 import com.runmate.domain.crew.CrewUser;
 import com.runmate.domain.redis.GoalForTempStore;
@@ -20,6 +21,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
@@ -31,6 +33,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
 @Transactional
+@ActiveProfiles(inheritProfiles = false, resolver = TestActiveProfilesResolver.class)
 public class RunningDataMoveToDiskTest {
     @Autowired
     TeamRepository teamRepository;

--- a/runmate-websocket/src/test/java/com/runmate/service/RunningDataMoveToMemTest.java
+++ b/runmate-websocket/src/test/java/com/runmate/service/RunningDataMoveToMemTest.java
@@ -1,5 +1,6 @@
 package com.runmate.service;
 
+import com.runmate.TestActiveProfilesResolver;
 import com.runmate.domain.crew.Crew;
 import com.runmate.domain.crew.CrewUser;
 import com.runmate.domain.redis.TeamInfo;
@@ -20,6 +21,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.transaction.TestTransaction;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -33,6 +35,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
 @Transactional
+@ActiveProfiles(inheritProfiles = false, resolver = TestActiveProfilesResolver.class)
 public class RunningDataMoveToMemTest {
     @Autowired
     TeamRepository teamRepository;

--- a/runmate-websocket/src/test/java/com/runmate/service/RunningDataMoveToMemTest.java
+++ b/runmate-websocket/src/test/java/com/runmate/service/RunningDataMoveToMemTest.java
@@ -31,6 +31,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
+import static java.time.LocalDateTime.now;
 import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
@@ -87,11 +88,15 @@ public class RunningDataMoveToMemTest {
     @Test
     void When_PersistRunningDataToMem_Initialize_Redis() {
         //given
+        final LocalDateTime startedAt = now().minus(1, ChronoUnit.HOURS);
+        final Long runningTime = 3700L;
+        final int numOfUser = 5;
+
         TestTransaction.flagForCommit();
         Goal goal = Goal.builder()
                 .totalDistance(10.0F)
-                .totalRunningSeconds(3600L)
-                .startedAt(LocalDateTime.now().plus(10, ChronoUnit.HOURS))
+                .totalRunningSeconds(runningTime)
+                .startedAt(startedAt)
                 .build();
         team = Team.builder()
                 .title("test team")
@@ -99,7 +104,6 @@ public class RunningDataMoveToMemTest {
                 .build();
         teamRepository.save(team);
 
-        final int numOfUser = 5;
         crew = textureFactory.makeCrew(true);
 
         for (int i = 0; i < numOfUser; i++) {
@@ -116,7 +120,6 @@ public class RunningDataMoveToMemTest {
             teamMemberRepository.save(teamMember);
             teamMembers.add(teamMember);
         }
-        redisTemplate.exec();
         TestTransaction.end();
 
         //when

--- a/runmate-websocket/src/test/java/com/runmate/service/RunningDataMoveToMemTest.java
+++ b/runmate-websocket/src/test/java/com/runmate/service/RunningDataMoveToMemTest.java
@@ -125,9 +125,9 @@ public class RunningDataMoveToMemTest {
         //then
         TeamInfo teamInfo = teamInfoRepository.findById(team.getId()).orElse(null);
 
-        assertEquals(teamInfo.getMembers().size(), teamMembers.size());
-        for (int i = 0; i < teamInfo.getMembers().size(); i++) {
-            assertEquals(teamInfo.getMembers().get(i), teamMembers.get(i).getId());
+        assertEquals(teamInfo.getOnlineMembers().size(), teamMembers.size());
+        for (int i = 0; i < teamInfo.getOnlineMembers().size(); i++) {
+            assertEquals(teamInfo.getOnlineMembers().get(i), teamMembers.get(i).getId());
         }
 
         assertEquals(teamInfo.getGoal().getDistance(), team.getGoal().getTotalDistance());

--- a/runmate-websocket/src/test/java/com/runmate/service/RunningDataMoveUnitTest.java
+++ b/runmate-websocket/src/test/java/com/runmate/service/RunningDataMoveUnitTest.java
@@ -1,0 +1,157 @@
+package com.runmate.service;
+
+import com.runmate.TestActiveProfilesResolver;
+import com.runmate.domain.redis.GoalForTempStore;
+import com.runmate.domain.redis.TeamInfo;
+import com.runmate.exception.CurrentIsNotRunningTimeException;
+import com.runmate.exception.MemberNotIncludedTeamException;
+import com.runmate.repository.redis.MemberInfoRepository;
+import com.runmate.repository.redis.TeamInfoRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static java.time.LocalDateTime.now;
+import static org.mockito.Mockito.*;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@SpringBootTest
+@ActiveProfiles(resolver = TestActiveProfilesResolver.class, inheritProfiles = false)
+public class RunningDataMoveUnitTest {
+    @Autowired
+    RunningDataMoveService runningDataMoveService;
+    @MockBean
+    TeamInfoRepository teamInfoRepository;
+    @MockBean
+    MemberInfoRepository memberInfoRepository;
+
+    final Long teamId = 1L;
+    final Long memberId = 1L;
+
+    @Test
+    void When_ParticipateInRunning_OverTheEndTime_Expect_Throws_CurrentIsNotRunningTimeException() {
+        //given
+        final LocalDateTime startTime = now().minus(2, ChronoUnit.HOURS);
+        final Long runningTime = 3600L;
+
+        List<Long> totalMembers = new ArrayList<>();
+        totalMembers.add(memberId);
+
+        GoalForTempStore goal = GoalForTempStore.builder()
+                .runningSeconds(runningTime)
+                .startedAt(startTime)
+                .distance(10F)
+                .build();
+
+        TeamInfo teamInfo = TeamInfo.builder()
+                .teamId(teamId)
+                .adminId(memberId)
+                .totalMembers(totalMembers)
+                .goal(goal)
+                .build();
+
+        when(teamInfoRepository.findById(teamId)).thenReturn(Optional.of(teamInfo));
+
+        //then
+        assertThrows(CurrentIsNotRunningTimeException.class, () -> {
+            runningDataMoveService.persistRunningDataToMem(teamId, memberId);
+        });
+    }
+
+    @Test
+    void When_ParticipateInRunning_NotStartedRunning_Expect_Throws_CurrentIsNotRunningTimeException() {
+        final LocalDateTime startTime = now().plus(3, ChronoUnit.HOURS);
+        final Long runningTime = 3600L;
+
+        List<Long> totalMembers = new ArrayList<>();
+        totalMembers.add(memberId);
+
+        GoalForTempStore goal = GoalForTempStore.builder()
+                .runningSeconds(runningTime)
+                .startedAt(startTime)
+                .distance(10F)
+                .build();
+
+        TeamInfo teamInfo = TeamInfo.builder()
+                .teamId(teamId)
+                .adminId(memberId)
+                .totalMembers(totalMembers)
+                .goal(goal)
+                .build();
+
+        when(teamInfoRepository.findById(teamId)).thenReturn(Optional.of(teamInfo));
+
+        //then
+        assertThrows(CurrentIsNotRunningTimeException.class, () -> {
+            runningDataMoveService.persistRunningDataToMem(teamId, memberId);
+        });
+    }
+
+    @Test
+    void When_ParticipateInRunning_NotIncludedInTeam_Expect_Throws_MemberNotIncludedTeamException() {
+        //given
+        final LocalDateTime startTime = now().minus(10, ChronoUnit.MINUTES);
+        final Long runningTime = 3600L;
+
+        List<Long> totalMembers = new ArrayList<>();//none
+
+        GoalForTempStore goal = GoalForTempStore.builder()
+                .runningSeconds(runningTime)
+                .startedAt(startTime)
+                .distance(10F)
+                .build();
+
+        TeamInfo teamInfo = TeamInfo.builder()
+                .teamId(teamId)
+                .adminId(memberId)
+                .totalMembers(totalMembers)
+                .goal(goal)
+                .build();
+
+        when(teamInfoRepository.findById(teamId)).thenReturn(Optional.of(teamInfo));
+
+        //then
+        assertThrows(MemberNotIncludedTeamException.class, () -> {
+            runningDataMoveService.persistRunningDataToMem(teamId, memberId);
+        });
+    }
+
+    @Test
+    void When_ParticipateInRunning_BetweenRunningTime_And_IncludedMember_Expect_OnlineMemberAdded() {
+        //given
+        final LocalDateTime startTime = now().minus(10, ChronoUnit.MINUTES);
+        final Long runningTime = 3600L;
+
+        List<Long> totalMembers = new ArrayList<>();
+        totalMembers.add(memberId);
+
+        GoalForTempStore goal = GoalForTempStore.builder()
+                .runningSeconds(runningTime)
+                .startedAt(startTime)
+                .distance(10F)
+                .build();
+
+        TeamInfo teamInfo = TeamInfo.builder()
+                .teamId(teamId)
+                .adminId(memberId)
+                .totalMembers(totalMembers)
+                .goal(goal)
+                .build();
+        when(teamInfoRepository.findById(teamId)).thenReturn(Optional.of(teamInfo));
+
+        //when
+        runningDataMoveService.persistRunningDataToMem(teamId, memberId);
+
+        //then
+        verify(teamInfoRepository, atLeastOnce()).save(any(TeamInfo.class));
+    }
+}


### PR DESCRIPTION
Connect에서 수행될 제약사항을 최대한 도메인쪽으로 옮기는 부분을 해결했습니다.

1)TeamInfo에 도메인 제약 사항 추가
2)Team->TeamMember의 연관관계 추가 및 TeamMember,CrewUser의 fetch 정책 수정
(N+1문제 때문)


StompChannelInterceptor의 수정은 다른 이슈로 등록 예정